### PR TITLE
Vue guide: `subscribeAll` needs an await

### DIFF
--- a/src/content/docs/docs/guides/vue.mdx
+++ b/src/content/docs/docs/guides/vue.mdx
@@ -495,7 +495,7 @@ function onSubmit() {
 
 async function doLoginActions() {
  isLoggedIn.value = true;
- todosCollection.subscribeAll({}, arrayMirrorSubscribeListener(fetchedTodos.value));
+ await todosCollection.subscribeAll({}, arrayMirrorSubscribeListener(fetchedTodos.value));
 }
 
 ...
@@ -640,7 +640,7 @@ That code change will render a delete button for each todo.
 
     async function doLoginActions() {
       isLoggedIn.value = true;
-      todosCollection.subscribeAll({}, arrayMirrorSubscribeListener(fetchedTodos.value));
+      await todosCollection.subscribeAll({}, arrayMirrorSubscribeListener(fetchedTodos.value));
     }
 
     // Perform login actions if the user is already logged in on page load


### PR DESCRIPTION
When calling `subscribeAll` is in an async function, we need to call `.await`
on it. Not doing so can result in future invocations on the collection to
happen _before_ `subscribeAll` completes, resulting in unexpected behavior.

In this case, if an application subscribes to the same, non-existant-yet,
collection twice in a row without `await` between them, it can result in an
attempt to create the same collection twice and a failure to subscribe the
second time.

In the example todo app documentation, this error cannot occur, but `.await` is
still more correct and encourages better practices of users in more complex
cases.
